### PR TITLE
Add command to cd into dot (hidden) directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note that the binary is installed only for the current user.
 - Ctrl-r: search past commands
 - Ctrl-x: execute past commands without confirmation
 - Alt-c: cd into directories
+- Alt-Shift-c (or Alt-C): cd into directories, including dot (hidden) ones
 
 On OS X, Alt-c (Option-c) types ç by default. In iTerm2, you can send the right escape sequence with Esc-c. If you configure the option key to act as +Esc (iTerm2 Preferences > Profiles > Default > Keys > Left option (⌥) acts as: > +Esc), then alt-c will work for fzf as documented.
 

--- a/functions/__fzf_alt_shift_c.fish
+++ b/functions/__fzf_alt_shift_c.fish
@@ -1,0 +1,14 @@
+function __fzf_alt_shift_c
+  set -q FZF_ALT_SHIFT_C_COMMAND
+  or set -l FZF_ALT_SHIFT_C_COMMAND "
+  command find -L . \
+  \\( -path '*/\\.git*' -o -fstype 'dev' -o -fstype 'proc' \\) -prune \
+  -o -type d -print 2> /dev/null | sed 1d | cut -b3-"
+  # Fish hangs if the command before pipe redirects (2> /dev/null)
+  fish -c "$FZF_ALT_SHIFT_C_COMMAND" | __fzfcmd -m $FZF_ALT_SHIFT_C_OPTS | \
+    read -la select
+  if test ! (count $select) -eq 0
+    cd $select
+  end
+  commandline -f repaint
+end

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -2,10 +2,12 @@ bind \ct '__fzf_ctrl_t'
 bind \cr '__fzf_ctrl_r'
 bind \cx '__fzf_ctrl_x'
 bind \ec '__fzf_alt_c'
+bind \eC '__fzf_alt_shift_c'
 
 if bind -M insert > /dev/null ^ /dev/null
   bind -M insert \ct '__fzf_ctrl_t'
   bind -M insert \cr '__fzf_ctrl_r'
   bind -M insert \cx '__fzf_ctrl_x'
   bind -M insert \ec '__fzf_alt_c'
+  bind -M insert \eC '__fzf_alt_shift_c'
 end


### PR DESCRIPTION
I sometimes want to go into hidden dirs. At first I had overriden the Alt-c command in my config.fish, but I have a lot of dot directories, so this became too slow.