### PR TITLE
Fix double escape of backslashes in history.

### DIFF
--- a/functions/__fish_history.fish
+++ b/functions/__fish_history.fish
@@ -9,7 +9,7 @@ function __fish_history
   if test -e ~/.config/fish/fish_history
     eval $QUERY_CMD ~/.config/fish/fish_history | grep "^\- cmd: " | sed 's/\- cmd: //' 
   else if test -e ~/.local/share/fish/fish_history
-    eval $QUERY_CMD ~/.local/share/fish/fish_history | grep "^\- cmd: " | sed 's/\- cmd: //'
+    eval $QUERY_CMD ~/.local/share/fish/fish_history | grep "^\- cmd: " | sed 's/\- cmd: //' | sed 's/\\\\\\\\/\\\/g'
   else
     history
   end


### PR DESCRIPTION
On Fish 2.4.0 I have noticed that if `\` appears in a command line entry, then when I would use `__fzf_reverse_isearch` then for an entry that was,

```bash
scp remote:\* ./
```
then the entry would show, and insert as,

```bash
scp remote:\\*
```

So I added an additional sed command that seemed to fix the issue.