### PR TITLE
fish 2.2 compatibility fixes

### DIFF
--- a/functions/__fzf_find_and_execute.fish
+++ b/functions/__fzf_find_and_execute.fish
@@ -1,5 +1,5 @@
 function __fzf_find_and_execute
-  builtin history --null | eval "__fzfcmd --read0 +s -m --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_FIND_AND_EXECUTE_OPTS" | read -z select
+  builtin history | eval "__fzfcmd +s -m --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_FIND_AND_EXECUTE_OPTS" | read select
   printf "\nexecuting: $select\n"
   eval $select
   commandline -f repaint

--- a/functions/__fzf_reverse_isearch.fish
+++ b/functions/__fzf_reverse_isearch.fish
@@ -1,7 +1,7 @@
 function __fzf_reverse_isearch
-  builtin history --null | eval "__fzfcmd --read0 +s --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_REVERSE_ISEARCH_OPTS -q (commandline)" | read -z select
+  builtin history | eval "__fzfcmd +s --tiebreak=index --toggle-sort=ctrl-r $FZF_DEFAULT_OPTS $FZF_REVERSE_ISEARCH_OPTS -q (commandline)" | read select
   if not test -z $select
-    commandline -rb (builtin string trim "$select")
+    commandline -rb "$select"
     commandline -f repaint
   end
 end


### PR DESCRIPTION
Greetings. Fish 2.2 is still in repositories of *last versions* of debian-based systems (Ubuntu 16, Debian 8), so it would be good to have compatibility with it.
Notes to patch:
`history --null` and `builtin string` is unavailable in fish2.2, so I removed related code, and it works the same way for me, but maybe I missed something?
Tnx in advance.