### PR TITLE
Remove __fzf_cd bind conflict with forward-delete

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -19,14 +19,14 @@ else
     bind \cf '__fzf_find_file'
     bind \cr '__fzf_reverse_isearch'
     bind \ex '__fzf_find_and_execute'
-    bind \ed '__fzf_cd'
-    bind \eD '__fzf_cd_with_hidden'
+    bind \eo '__fzf_cd'
+    bind \eO '__fzf_cd_with_hidden'
 
     if bind -M insert >/dev/null ^/dev/null
         bind -M insert \cf '__fzf_find_file'
         bind -M insert \cr '__fzf_reverse_isearch'
         bind -M insert \ex '__fzf_find_and_execute'
-        bind -M insert \ed '__fzf_cd'
-        bind -M insert \eD '__fzf_cd_with_hidden'
+        bind -M insert \eo '__fzf_cd'
+        bind -M insert \eO '__fzf_cd_with_hidden'
     end
 end


### PR DESCRIPTION
Alt-d is used by fish's 'kill-word' in fish_default_key_bindings and
fish_hybrid_key_bindings. This changes __fzf_cd and __fzf_cd_with_hidden
to use Alt-o and Alt-O (o for Open) instead.