### PR TITLE
use `eval` instead of subshell to execute command

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -4,7 +4,7 @@ function __fzf_cd
   command find -L . \\( -path '*/\\.*' -o -fstype 'dev' -o -fstype 'proc' \\) -prune \
   -o -type d -print 2> /dev/null | sed 1d | cut -b3-"
   # Fish hangs if the command before pipe redirects (2> /dev/null)
-  fish -c "$FZF_CD_COMMAND" | eval "__fzfcmd -m $FZF_CD_OPTS" | read -l select
+  eval "$FZF_CD_COMMAND" | eval "__fzfcmd -m $FZF_CD_OPTS" | read -l select
   if not test -z "$select"
     cd "$select"
   end

--- a/functions/__fzf_cd_with_hidden.fish
+++ b/functions/__fzf_cd_with_hidden.fish
@@ -5,7 +5,7 @@ function __fzf_cd_with_hidden
   \\( -path '*/\\.git*' -o -fstype 'dev' -o -fstype 'proc' \\) -prune \
   -o -type d -print 2> /dev/null | sed 1d | cut -b3-"
   # Fish hangs if the command before pipe redirects (2> /dev/null)
-  fish -c "$FZF_CD_WITH_HIDDEN_COMMAND" | eval "__fzfcmd -m $FZF_DEFAULT_OPTS $FZF_CD_WITH_HIDDEN_OPTS" | \
+  eval "$FZF_CD_WITH_HIDDEN_COMMAND" | eval "__fzfcmd -m $FZF_DEFAULT_OPTS $FZF_CD_WITH_HIDDEN_OPTS" | \
   read -la select
   if test ! (count $select) -eq 0
     cd "$select"

--- a/functions/__fzf_find_file.fish
+++ b/functions/__fzf_find_file.fish
@@ -4,7 +4,7 @@ function __fzf_find_file
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null"
-  fish -c "$FZF_FIND_FILE_COMMAND" | eval "__fzfcmd -m $FZF_DEFAULT_OPTS $FZF_FIND_FILE_OPTS" | while read -l s; set selects $selects $s; end
+  eval "$FZF_FIND_FILE_COMMAND" | eval "__fzfcmd -m $FZF_DEFAULT_OPTS $FZF_FIND_FILE_OPTS" | while read -l s; set selects $selects $s; end
   for select in $selects
     commandline -it -- "\"$select\""
     commandline -it -- " "


### PR DESCRIPTION
`fish -c` is opening a subshell and thus executes fish's startup code, e.g. in `config.fish`. If initialization produces output, then whatever is printed interferes with the output of `fzf`.
I came across the problem during configuration of the MBP Touchbar, where the touchbar is updated by `echo` with a special escape sequence. That is then part of the `fzf` display.

Using `eval` solves the problem, because it just executes the command without starting a new subshell and thus doesn't execute initialization code.