### PR TITLE
Change to expand variables before passing to eval

### DIFF
--- a/functions/__fzf_cd.fish
+++ b/functions/__fzf_cd.fish
@@ -26,7 +26,7 @@ function __fzf_cd -d "Change directory"
         set COMMAND $FZF_CD_COMMAND
     end
 
-    eval "$COMMAND | "(__fzfcmd)' +m $FZF_DEFAULT_OPTS $FZF_CD_OPTS --query "'$fzf_query'"' | read -l select
+    eval "$COMMAND | "(__fzfcmd)" +m $FZF_DEFAULT_OPTS $FZF_CD_OPTS --query \"$fzf_query\"" | read -l select
 
     if not test -z "$select"
         cd "$select"

--- a/functions/__fzf_find_file.fish
+++ b/functions/__fzf_find_file.fish
@@ -11,7 +11,7 @@ function __fzf_find_file -d "List files and folders"
     -o -type l -print 2> /dev/null | sed 's@^\./@@'"
 
     begin
-        eval "$FZF_FIND_FILE_COMMAND | "(__fzfcmd) '-m $FZF_DEFAULT_OPTS $FZF_FIND_FILE_OPTS --query "'$fzf_query'"' | while read -l s; set results $results $s; end
+        eval "$FZF_FIND_FILE_COMMAND | "(__fzfcmd) "-m $FZF_DEFAULT_OPTS $FZF_FIND_FILE_OPTS --query \"$fzf_query\"" | while read -l s; set results $results $s; end
     end
 
     if test -z "$results"


### PR DESCRIPTION
I ran the `fisher up` command and downloaded the fisherman/fzf current master branch.

After that, when I pressed `Ctrl-f` the following error message displayed.

```
unknown option: --height 40%
```

This problem was found  at `fish version 2.7.1` and `fzf version 0.17.3` of `Ubuntu 14.04.5 LTS` and `macOS High Sierra (10.13.3)`.

I thought there was a problem with variable expansion with the following functions.

https://github.com/fisherman/fzf/blob/master/functions/__fzf_find_file.fish#L14
https://github.com/fisherman/fzf/blob/master/functions/__fzf_cd.fish#L29

Will it work  without problem if its in other environments?