### PR TITLE
Remove legacy carat redirection from key_bindings

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -24,4 +24,6 @@ else
     end
 end
 
-set -q FZF_COMPLETE ;and bind \t '__fzf_complete'
+if set -q FZF_COMPLETE
+    bind \t '__fzf_complete'
+end

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -4,7 +4,7 @@ if test "$FZF_LEGACY_KEYBINDINGS" -eq 1
     bind \ec '__fzf_cd'
     bind \eC '__fzf_cd_with_hidden'
 
-    if bind -M insert >/dev/null ^/dev/null
+    if bind -M insert >/dev/null 2>/dev/null
         bind -M insert \ct '__fzf_find_file'
         bind -M insert \cr '__fzf_reverse_isearch'
         bind -M insert \ec '__fzf_cd'
@@ -16,7 +16,7 @@ else
     bind \eo '__fzf_cd'
     bind \eO '__fzf_cd --hidden'
 
-    if bind -M insert >/dev/null ^/dev/null
+    if bind -M insert >/dev/null 2>/dev/null
         bind -M insert \cf '__fzf_find_file'
         bind -M insert \cr '__fzf_reverse_isearch'
         bind -M insert \eo '__fzf_cd'


### PR DESCRIPTION
This fixes breakage in fish 3.0