### PR TITLE
__fzf_open stores the command to open the file in history

### DIFF
--- a/functions/__fzf_open.fish
+++ b/functions/__fzf_open.fish
@@ -37,9 +37,8 @@ function __fzf_open -d "Open files and directories."
 
     set -l open_status 0
     if not test -z "$select"
-        eval "$open_cmd $select"
+        commandline "$open_cmd $select" ;and commandline -f execute
         set open_status $status
-        commandline -t ""
     end
 
     commandline -f repaint


### PR DESCRIPTION
Hi all,

This is in (self) response to #74 😄 

I don't know much about fish scripting so the guarantee on this is on the basis of _It Works On My Machine_ ™️

Whilst testing on my machine it seems to do what I want (applies to `Ctrl-o` and `Ctrl-g`). I don't know if this is desired behaviour by the authors, though. 

Cheers